### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,12 @@ plugins {
     id "com.gradle.plugin-publish" version "0.10.0"
     id "com.github.hierynomus.license" version "0.14.0"
     id 'maven-publish' // used for publishing to local maven repository
+    id 'com.gradle.build-scan' version '2.1'
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
+    id 'com.gradle.build-scan' version '2.1'
     id 'java-gradle-plugin'
     id 'groovy'
     id "com.gradle.plugin-publish" version "0.10.0"
     id "com.github.hierynomus.license" version "0.14.0"
     id 'maven-publish' // used for publishing to local maven repository
-    id 'com.gradle.build-scan' version '2.1'
 }
 
 buildScan {

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -ev
-./gradlew --no-daemon -i -s build
+./gradlew --no-daemon -i -s --scan build


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.