### PR TITLE
Fix `addMainModuleInfo` erroneously considered UP-TO-DATE

### DIFF
--- a/src/main/groovy/org/moditect/gradleplugin/add/AddMainModuleInfoTask.groovy
+++ b/src/main/groovy/org/moditect/gradleplugin/add/AddMainModuleInfoTask.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.WorkResult
@@ -33,7 +34,7 @@ import org.moditect.gradleplugin.add.model.MainModuleConfiguration
 class AddMainModuleInfoTask extends AbstractAddModuleInfoTask {
     private static final Logger LOGGER = Logging.getLogger(AddMainModuleInfoTask)
 
-    @Input @Optional
+    @Nested @Optional
     final Property<MainModuleConfiguration> mainModule
 
     AddMainModuleInfoTask() {

--- a/src/main/groovy/org/moditect/gradleplugin/add/model/AbstractModuleConfiguration.groovy
+++ b/src/main/groovy/org/moditect/gradleplugin/add/model/AbstractModuleConfiguration.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -44,9 +45,13 @@ abstract class AbstractModuleConfiguration {
     @Input @Optional
     String mainClass
 
+    @Input
     abstract String getShortName()
+    @InputFile
     abstract File getInputJar()
+    @Input
     abstract String getVersion()
+    @Nested
     abstract Set<ModuleId> getOptionalDependencies()
 
     AbstractModuleConfiguration(Project project) {

--- a/src/main/groovy/org/moditect/gradleplugin/add/model/ModuleConfiguration.groovy
+++ b/src/main/groovy/org/moditect/gradleplugin/add/model/ModuleConfiguration.groovy
@@ -100,7 +100,6 @@ class ModuleConfiguration extends AbstractModuleConfiguration {
         primaryArtifact.file
     }
 
-    @Input
     @Override
     String getVersion() {
         primaryArtifact.moduleVersion.id.version

--- a/src/main/groovy/org/moditect/gradleplugin/common/ModuleId.groovy
+++ b/src/main/groovy/org/moditect/gradleplugin/common/ModuleId.groovy
@@ -16,9 +16,12 @@
 package org.moditect.gradleplugin.common
 
 import groovy.transform.Canonical
+import org.gradle.api.tasks.Input
 
 @Canonical
 class ModuleId implements Serializable {
+    @Input
     String group
+    @Input
     String name
 }


### PR DESCRIPTION
The `addMainModuleInfo` task replaces the original JAR with a modifies JAR. However, previously it did not properly specify the task inputs, therefore it was erroneously considered UP-TO-DATE even if the JAR changed.

Note that now unfortunately the `jar` task is always run and never considered UP-TO-DATE because `addMainModuleInfo` modified the original JAR. Not sure if that can be solved in a cleaner way. Though interestingly manually specifying the JAR in the `build.gradle.kts` with `inputs.file(mainModule.get().inputJar)` does not cause the `jar` task to be re-run (though maybe that also depends on the Gradle version being used).

I am not that familiar with Gradle so any feedback is appreciated!
Note that there are some parts which I have not tested; if you want I can omit those and only add the annotations necessary for `getInputJar()`.